### PR TITLE
Fixed nil value when not in a raid group.

### DIFF
--- a/modules/units.lua
+++ b/modules/units.lua
@@ -731,7 +731,9 @@ function Units:LoadGroupHeader(unit)
 		header:Show()
 		header:SetMovable(0)
 	end
-	RaidGroupFrame_Update() -- make sure info is current
+	if ( RaidGroupFrame_Update ) then
+		RaidGroupFrame_Update() -- make sure info is current
+	end
 	header.Update(unit)
 end
 
@@ -784,8 +786,9 @@ function Units:LoadRaidGroupHeader()
 		else
 			header:SetMovable(0)
 		end
-
-		RaidGroupFrame_Update() -- make sure info is current
+		if ( RaidGroupFrame_Update ) then
+			RaidGroupFrame_Update() -- make sure info is current
+		end
 		header.Update(header)
 	end
 end


### PR DESCRIPTION
![Screenshot_2025-03-29-31_1920x1080](https://github.com/user-attachments/assets/b963fbe8-0b4b-4574-8eb3-01c4ac849220)
- added condition to avoid calling `RaidGroupFrame_Update` when not in a raid group.