### PR TITLE
Fix the threat tags.

### DIFF
--- a/modules/threat.lua
+++ b/modules/threat.lua
@@ -22,7 +22,7 @@ Threat.tankNotify = false
 
 function Threat:OnEnable()
 	-- turtle-wow check
-	if string.find(GetBuildInfo(),"^1.17.") then
+	if string.find(GetBuildInfo(),"^1.18.") then
 		self:RegisterEvent("PLAYER_REGEN_DISABLED")
 		self:RegisterEvent("PLAYER_REGEN_ENABLED")
 		self:RegisterEvent("PLAYER_ENTERING_WORLD")


### PR DESCRIPTION
Threat module has a weird way to check if it is TurtleWoW based on build version. Bump to the current version fixes module not loading. `[threat]` etc. should now work.